### PR TITLE
fix(jenkins): skip Modrinth publish for stale tag builds — guard agai…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -189,14 +189,39 @@ pipeline {
                     env.IS_TAG = tagCheck.startsWith('v') ? 'true' : 'false'
                     env.GIT_TAG = tagCheck
 
+                    // ── En son tag kontrolü (v2.3.0+) ──
+                    // Multibranch Pipeline ilk SCM scan'da eski tag'leri (v2.2.6,
+                    // v2.2.7, vs.) yanlışlıkla build edebiliyor. Bu, ESKİ versiyonların
+                    // yanlışlıkla "latest" olarak Modrinth'e yayınlanmasına yol açar.
+                    // Bu guard: tag build'i sadece TÜM tag'ler arasında EN YÜKSEK
+                    // versiyon olduğunda yayın stage'lerini çalıştırır.
+                    if (env.IS_TAG == 'true') {
+                        def latestTag = sh(
+                            script: "git tag --list 'v*' --sort=-v:refname | head -1",
+                            returnStdout: true
+                        ).trim()
+                        if (latestTag && latestTag != env.GIT_TAG) {
+                            echo "⚠️  Bu en son tag DEĞİL (current: ${env.GIT_TAG}, latest: ${latestTag})"
+                            echo "    Yayın stage'leri ATLANIYOR — eski tag'in yanlışlıkla 'latest' olarak"
+                            echo "    Modrinth'e yayınlanmasını önler. Sadece build doğrulaması yapılır."
+                            env.RELEASE_TYPE = 'none'
+                            env.SKIPPED_OLD_TAG = 'true'
+                        }
+                    }
+
                     // ── Branch adı ──
                     env.BRANCH_NAME_CLEAN = sh(
                         script: "echo '${env.BRANCH_NAME ?: env.GIT_BRANCH}' | sed 's|origin/||' | sed 's|/|-|g'",
                         returnStdout: true
                     ).trim()
 
-                    // ── Release türü ──
-                    if (env.IS_TAG == 'true') {
+                    // ── Release türü (eski-tag guard'ı zaten yukarıda RELEASE_TYPE='none' ayarladıysa skip et) ──
+                    if (env.RELEASE_TYPE == 'none' && env.SKIPPED_OLD_TAG == 'true') {
+                        // Guard zaten karar verdi — versiyon string'lerini bilgi amaçlı doldur
+                        env.RELEASE_VERSION = env.BASE_VERSION
+                        env.TAG_NAME        = env.GIT_TAG
+                        env.RELEASE_TITLE   = "AtomGuard v${env.BASE_VERSION} (eski tag — yayın atlandı)"
+                    } else if (env.IS_TAG == 'true') {
                         env.RELEASE_TYPE    = 'stable'
                         env.RELEASE_VERSION = env.BASE_VERSION
                         env.TAG_NAME        = "v${env.BASE_VERSION}"


### PR DESCRIPTION
…nst accidental old-version releases

Sorun:
- Multibranch Pipeline ilk SCM scan'inde uzun süredir Jenkins'in görmediği eski tag'leri (v2.2.6, v2.2.7, v2.2.9) kuyruğa alıyor ve EN ESKİDEN başlayarak build ediyor.
- Eski Jenkinsfile'da bu tag'ler de RELEASE_TYPE='stable' alıyor ve Modrinth'e v2.2.6 olarak yayınlanıyor — bu, kullanıcıların "en son sürüm" olarak ESKİ kodu indirmesine yol açar (regresyon).

Düzeltme:
- Resolve Version stage'inde "en yüksek versiyonlu tag" kontrolü eklendi.
- Eğer build edilen tag, repo'daki EN YÜKSEK semver tag'i değilse, RELEASE_TYPE='none' atanıyor — Modrinth ve GitHub release stage'leri ATLANIYOR. Sadece build doğrulaması yapılıyor.
- SKIPPED_OLD_TAG flag'i ile bilgilendirici release title üretiliyor.

Test:
- v2.2.6 tag'i build edilirse: latest = v2.3.0, current ≠ latest → SKIP
- v2.3.0 tag'i build edilirse: latest = v2.3.0, current = latest → PUBLISH
- main branch build'i: tag yok → mevcut akış (dev build)