### PR TITLE
Improve whitelist.json corruption handling with backup & format support

### DIFF
--- a/core/src/main/java/com/atomguard/manager/WhitelistManager.java
+++ b/core/src/main/java/com/atomguard/manager/WhitelistManager.java
@@ -3,6 +3,7 @@ package com.atomguard.manager;
 import com.atomguard.AtomGuard;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.NotNull;
@@ -12,7 +13,11 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -56,21 +61,74 @@ public class WhitelistManager {
             }
             String json = Files.readString(filePath, StandardCharsets.UTF_8);
             if (json.isBlank()) return;
-            Map<String, String> raw = gson.fromJson(json,
-                    new TypeToken<Map<String, String>>(){}.getType());
-            if (raw != null) {
-                whitelist.clear();
-                for (Map.Entry<String, String> e : raw.entrySet()) {
-                    try {
-                        whitelist.put(UUID.fromString(e.getKey()), e.getValue());
-                    } catch (IllegalArgumentException ignored) {
-                        // Bozuk UUID — yoksay
-                    }
-                }
-                plugin.getLogger().info("Whitelist yüklendi: " + whitelist.size() + " oyuncu.");
+
+            Map<String, String> raw = parseWhitelist(json);
+            if (raw == null) {
+                backupCorruptedFile();
+                return;
             }
+
+            whitelist.clear();
+            for (Map.Entry<String, String> e : raw.entrySet()) {
+                try {
+                    whitelist.put(UUID.fromString(e.getKey()), e.getValue());
+                } catch (IllegalArgumentException ignored) {
+                    // Bozuk UUID — yoksay
+                }
+            }
+            plugin.getLogger().info("Whitelist yüklendi: " + whitelist.size() + " oyuncu.");
         } catch (IOException e) {
             plugin.getLogger().warning("Whitelist yüklenemedi: " + e.getMessage());
+        }
+    }
+
+    /**
+     * whitelist.json içeriğini birden fazla desteklenen formattan parse etmeyi
+     * dener. Hiçbiri uymazsa {@code null} döner; caller dosyayı yedekler ve
+     * boş whitelist ile devam eder. Bu sayede bozuk JSON tüm eklenti
+     * yüklemesini durdurmaz.
+     */
+    @Nullable
+    private Map<String, String> parseWhitelist(@NotNull String json) {
+        // Format 1: {"uuid": "name", ...}  (mevcut format)
+        try {
+            Map<String, String> map = gson.fromJson(json,
+                    new TypeToken<Map<String, String>>(){}.getType());
+            if (map != null) return map;
+        } catch (JsonSyntaxException ignored) {
+            // diğer formatları dene
+        }
+
+        // Format 2: ["uuid", "uuid", ...]  (eski/elle düzenlenmiş format)
+        try {
+            List<String> list = gson.fromJson(json,
+                    new TypeToken<List<String>>(){}.getType());
+            if (list != null) {
+                Map<String, String> map = new HashMap<>();
+                for (String uuid : list) {
+                    if (uuid != null) map.put(uuid, uuid);
+                }
+                return map;
+            }
+        } catch (JsonSyntaxException ignored) {
+            // düş
+        }
+
+        plugin.getLogger().warning(
+                "whitelist.json tanınmayan veya bozuk formatta; boş whitelist ile başlanıyor.");
+        return null;
+    }
+
+    /** Bozuk whitelist.json dosyasını yedekle (yan-yana .bak-<timestamp>). */
+    private void backupCorruptedFile() {
+        try {
+            String stamp = LocalDateTime.now()
+                    .format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"));
+            Path backup = filePath.resolveSibling(FILE_NAME + ".corrupt-" + stamp + ".bak");
+            Files.move(filePath, backup, StandardCopyOption.REPLACE_EXISTING);
+            plugin.getLogger().warning("Bozuk whitelist.json yedeklendi: " + backup.getFileName());
+        } catch (IOException e) {
+            plugin.getLogger().warning("Bozuk whitelist.json yedeklenemedi: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
## Summary
Enhanced the `WhitelistManager` to gracefully handle corrupted or malformed `whitelist.json` files by implementing automatic backup and multi-format parsing. This prevents a single corrupted whitelist file from blocking the entire plugin startup.

## Key Changes
- **Multi-format parsing**: Added `parseWhitelist()` method that attempts to parse whitelist.json in multiple formats:
  - Format 1 (current): `{"uuid": "name", ...}` (Map<String, String>)
  - Format 2 (legacy/manual edits): `["uuid", "uuid", ...]` (List<String>)
  - Falls back gracefully if neither format matches
  
- **Automatic backup on corruption**: Implemented `backupCorruptedFile()` that creates a timestamped backup (e.g., `whitelist.json.corrupt-20250115-143022.bak`) when JSON parsing fails, preserving the corrupted file for investigation while allowing the plugin to continue with an empty whitelist

- **Improved error handling**: Wrapped JSON parsing in try-catch blocks with `JsonSyntaxException` to distinguish between parse errors and null results

- **Better logging**: Added warning messages in Turkish when whitelist.json is unrecognized or corrupted, and when backup succeeds/fails

## Implementation Details
- Added imports: `JsonSyntaxException`, `StandardCopyOption`, `LocalDateTime`, `DateTimeFormatter`, `List`
- Refactored the `load()` method to use the new `parseWhitelist()` helper, reducing nesting and improving readability
- Timestamp format: `yyyyMMdd-HHmmss` for backup filenames
- Backup operation uses `Files.move()` with `REPLACE_EXISTING` to handle edge cases
- All new methods include Turkish documentation comments consistent with project conventions

https://claude.ai/code/session_01G6dXgT3nKS8Zne6FU6z2C6